### PR TITLE
Add initial structure to repository

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -55,14 +55,14 @@ jobs:
     
     steps:
      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
 
       - uses: actions/checkout@v3
     
       - name: "Install mypackage"
         run: pip3 install .[test]
 
-      - name: Mypy check
+      - name: Run tests
         run: |
-          python3 -m pytest test
+          python3 -m pytest test/

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -25,13 +25,11 @@ jobs:
     steps:
       # This action sets the current path to the root of your github repo
       - uses: actions/checkout@v3
-
-      - name: "Install dependencies"
-        run: |
-           sudo apt-get update
-           sudo apt-get install -y python3-pip
-           pip3 install --upgrade pip setuptools
-           sudo apt purge -y python3-setuptools
+      
+      - name: Set up Python
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
 
       - name: "Install code"
         run: pip install .[test,docs]
@@ -42,7 +40,7 @@ jobs:
       - name: Mypy check
         run: |
            pip install mypy
-           python3 -m mypy . --exclude=build
+           python -m mypy . --exclude=build
 
   test-code:
     # This code depends on the result of check-code
@@ -61,8 +59,8 @@ jobs:
       - uses: actions/checkout@v3
     
       - name: "Install mypackage"
-        run: pip3 install .[test]
+        run: pip install .[test]
 
       - name: Run tests
         run: |
-          python3 -m pytest test/
+          python -m pytest test/

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,0 +1,63 @@
+name: Test package
+
+on:
+  push:
+    # The CI is executed on every push on every branch
+    branches:
+      - "**"
+  pull_request:
+    # The CI is executed on every pull request to the main branch
+    branches:
+      - main
+
+  schedule:
+    # The CI is executed every day at 8am
+    - cron: "0 8 * * *"
+jobs:
+  check-code:
+    # This skips running the test if '[ci skip]' or '[skip ci]' is in the commit message
+    # if: "!(contains(github.event.head_commit.message, '[ci skip]') || contains(github.event.head_commit.message, '[skip ci]'))"
+
+    # Choose which operating system to run on, for more options see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+    runs-on: ubuntu-22.04
+
+    steps:
+      # This action sets the current path to the root of your github repo
+      - uses: actions/checkout@v3
+
+      - name: "Install dependencies"
+        run: |
+           apt-get update
+           apt-get install -y python3-pip
+           pip3 install --upgrade pip setuptools
+           apt purge -y python3-pip
+
+      - name: "Install code"
+        run: pip install .[test,docs]
+
+      - name: Flake8 code
+        run: flake8 .
+
+      - name: Mypy check
+        run: |
+           pip install mypy
+           python3 -m mypy . --exclude=build
+
+  test-code:
+    # This code depends on the result of check-code
+    needs: check-code
+    
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-12]    
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Install mypackage"
+        run: pip3 install .[test]
+
+      - name: Mypy check
+        run: |
+          python3 -m pytest test

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -41,6 +41,19 @@ jobs:
            pip install mypy
            python -m mypy . --exclude=build
 
+      - name: Generate coverage report
+        run: python -m pytest --cov=mypackage test
+
+      - name: Generate html report
+        run: python -m coverage html
+           
+      - name: Upload coverage report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: htmlcov
+          if-no-files-found: error
+
   test-code:
     # This code depends on the result of check-code
     needs: check-code

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -31,7 +31,7 @@ jobs:
            sudo apt-get update
            sudo apt-get install -y python3-pip
            pip3 install --upgrade pip setuptools
-           sudo apt purge -y python3-pip
+           sudo apt purge -y python3-setuptools
 
       - name: "Install code"
         run: pip install .[test,docs]

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -47,6 +47,7 @@ jobs:
   test-code:
     # This code depends on the result of check-code
     needs: check-code
+    runs-on: ${{ matrix.os }}
     
     strategy:
       matrix:

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -26,7 +26,6 @@ jobs:
       # This action sets the current path to the root of your github repo
       - uses: actions/checkout@v3
       
-      - name: Set up Python
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10' 
@@ -52,9 +51,9 @@ jobs:
         os: [ubuntu-22.04, windows-latest, macos-12]    
     
     steps:
-     
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
 
       - uses: actions/checkout@v3
     

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-           apt-get update
-           apt-get install -y python3-pip
+           sudo apt-get update
+           sudo apt-get install -y python3-pip
            pip3 install --upgrade pip setuptools
-           apt purge -y python3-pip
+           sudo apt purge -y python3-pip
 
       - name: "Install code"
         run: pip install .[test,docs]

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -54,8 +54,12 @@ jobs:
         os: [ubuntu-22.04, windows-latest, macos-12]    
     
     steps:
-      - uses: actions/checkout@v3
+     
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
 
+      - uses: actions/checkout@v3
+    
       - name: "Install mypackage"
         run: pip3 install .[test]
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # reproducibility
+
+This repository is a template for how to set up a reproducible python environment with GitHub.
+
+## Python-packaging
+
+To be able to create a python package, we need a folder with the name of the package (in this repository `mypackage`), and a `pyproject.toml` file.

--- a/mypackage/__init__.py
+++ b/mypackage/__init__.py
@@ -1,0 +1,9 @@
+
+# Copyright (C) 2022 Jørgen Schartum Dokken
+#
+# This file is part of my_package
+# SPDX-License-Identifier:    MIT
+
+from .functions import addition
+
+__all__ = ["addition"]

--- a/mypackage/functions.py
+++ b/mypackage/functions.py
@@ -1,0 +1,10 @@
+
+
+# Copyright (C) 2022 Jørgen Schartum Dokken
+#
+# This file is part of my_package
+# SPDX-License-Identifier:    MIT
+
+def addition(a: int, b: int) -> int:
+    """ Computes a+b """
+    return a + b

--- a/mypackage/functions.py
+++ b/mypackage/functions.py
@@ -2,9 +2,15 @@
 
 # Copyright (C) 2022 Jørgen Schartum Dokken
 #
-# This file is part of my_package
+# This file is part of mypackage
 # SPDX-License-Identifier:    MIT
 
 def addition(a: int, b: int) -> int:
     """ Computes a+b """
     return a + b
+
+
+def print_add(a: int, b: int) -> int:
+    c = a + b
+    print(c)
+    return c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=62.1.0", "wheel"]
+
+
+[project]
+name = "mypackage"
+authors = [
+    {name = "Jørgen S. Dokken", email = "dokken@simula.no"}
+    ]
+version = "0.1.0"  
+description = "Minimal package for adding two numbers"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+dependencies = [
+    'numpy'
+]
+
+
+[project.optional-dependencies]
+test = [
+   "flake8",
+   "mypy",
+   "pytest",
+   "pytest-cov"
+]
+
+docs = [
+    "Sphinx",
+    "jupyter-book",
+    "pandoc"
+]
+
+[tool.mypy]
+ignore_missing_imports = true
+exclude = [
+    "docs/",
+    "build/"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+# flake8 does not support, see:
+# https://github.com/PyCQA/flake8/issues/234
+[flake8]
+exclude = docs
+max-line-length = 100
+
+

--- a/test/test_code.py
+++ b/test/test_code.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2022 Jørgen Schartum Dokken
+#
+# This file is part of my_package
+# SPDX-License-Identifier:    MIT
+
+from mypackage import addition
+
+
+def test_addition():
+    a = 5
+    b = 3
+    assert addition(a, b) == a + b


### PR DESCRIPTION
- Adds a minimal package `mypackage` with a corresponding `pyproject.toml` file describing the package, and its dependencies for testing/documentation. This makes it `pip`-installable, i.e. `pip3 install .` from the root of the repository will install the package.
- Testing added in `.github/workflows/test_package.yml`
  - Shows how to setup scheduled runs (for instance running every day at 8am)
  - Shows how to use tools such as `mypy` and `flake8` on the package.
- Shows how to set up a minimal testing environment on:
  - Ubuntu 22.04
  - Mac os 12
  - Windows server 2022
- Minimal script using `pytest` for testing code.   