### PR TITLE
Add demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# We create a simple docker file that install the necesseary dependencies for the package
+
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y python3-pip
+
+# Use modern setuptools from pip instead of apt
+RUN pip3 install pip setuptools --upgrade
+
+RUN apt-get purge python3-setuptools
+
+# Create user with a home directory
+ARG NB_USER
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+# Copy home directory for usage in binder
+WORKDIR ${HOME}
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+
+USER ${NB_USER}
+ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 doc: # Generate Sphinx HTML documentation, including API docs
-	cp README.md docs/README.md
+# We want to use the README.md file from the folder as the front page of the book.
+# It has been added to _toc.yml as root
+	cp README.md docs/README.md 
+# We want to use the demos in the book, we convert them with jupytext and copy them to the documentation
+	jupytext --to=ipynb demos/demo.py --output=docs/demo.ipynb
 	jupyter book build docs
 
 clean-pytest: # Remove output from pytest

--- a/demos/demo.py
+++ b/demos/demo.py
@@ -1,0 +1,33 @@
+# + [markdown]
+# # An introduction to the light format
+#
+# Author: Jørgen S. Dokken
+#
+# SPDX-License-Identifier:    MIT
+# -
+
+# + [markdown]
+# We start a new cell explicitly by using the "+" sign and can explicitly end
+# it by using the "-" sign.
+# -
+
+# If we do not use explicit indicators for starting or ending a cell, it creates a
+# new cell whenever there is a blank line
+
+# This is a new cell
+
+# Comments can be added to code by not adding a new line before the code
+import mypackage
+
+# Next we define two numbers, `a` and `b`
+
+a = 1
+b = 3
+
+# and add them together
+
+c = mypackage.addition(a, b)
+
+# We check the result
+
+assert c == a + b

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,6 +26,13 @@ sphinx:
   - 'sphinx.ext.viewcode'
 
 
+launch_buttons:
+  notebook_interface: "jupyterlab" # The interface interactive links will activate ["classic", "jupyterlab"]
+  binderhub_url: "https://mybinder.org"
+  colab_url: "https://colab.research.google.com"
+
+
+
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -2,4 +2,5 @@ format: jb-book
 root: README
 
 chapters:
+  - file: "demo"
   - file: "api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = ["setuptools>=62.1.0", "wheel"]
 
+[tool.setuptools]
+py-modules = ["mypackage"]
 
 [project]
 name = "mypackage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ test = [
 docs = [
     "sphinx",
     "jupyter-book",
-    "pandoc"
+    "jupytext"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Add a simply demo using `Python light format`, such that it can easily be converted to an `ipynb` file, and used in the `jupyterbook`.

Add dockerfile for launch buttons

Resolves #9 